### PR TITLE
Pass credentials to gspread correctly

### DIFF
--- a/lab06/gspread_import.py
+++ b/lab06/gspread_import.py
@@ -9,6 +9,6 @@ scope = ['https://spreadsheets.google.com/feeds', 'https://www.googleapis.com/au
 creds = ServiceAccountCredentials.from_json_keyfile_dict(json.loads(os.environ['GOOGLE_SHEETS_READONLY_KEY']), scope)
 
 def get_spreadsheet(url, sheet_name):
-    spread = Spread(creds, url)
+    spread = Spread(url, creds=creds)
     sheet_df = spread.sheet_to_df(sheet=sheet_name, index=None)
     return Table.from_df(sheet_df)


### PR DESCRIPTION
Per https://gspread-pandas.readthedocs.io/en/latest/gspread_pandas.html#gspread_pandas.spread.Spread, 
'creds' is a named argument, so we should more explicit. Currently, 'creds' was being passed to the 'sheet'
argument.